### PR TITLE
Convert private spaces to public if the founder leaves

### DIFF
--- a/service/lib/spaces.ex
+++ b/service/lib/spaces.ex
@@ -22,6 +22,9 @@ defmodule LiveShareSpaces do
     opts = [strategy: :one_for_one, name: HexVersion.Supervisor]
     result = Supervisor.start_link(children, opts)
 
+    # Temporary migration for empty private communities that are unusable
+    LiveShareSpaces.SpaceStore.migrate_empty_private_spaces()
+
     result
   end
 


### PR DESCRIPTION
And also adds a (temporary) migration for empty private spaces that are unusable (like `vsls`)