### PR TITLE
Update load API endpoint to use token email

### DIFF
--- a/service/lib/spaces/auth.ex
+++ b/service/lib/spaces/auth.ex
@@ -433,7 +433,7 @@ defmodule LiveShareSpaces.Authentication do
         else
           response = Poison.decode!(response.body)
           name = response["name"]
-          email = response["userName"]
+          email = response["email"]
           LiveShareSpaces.ProfileStore.create_profile(id, name, email)
           claims = create_user_payload(id, name, email, "cascade")
           {:ok, claims}

--- a/service/lib/spaces/http.ex
+++ b/service/lib/spaces/http.ex
@@ -80,20 +80,11 @@ defmodule LiveShareSpaces.HTTP do
   end
 
   get "/v0/load" do
-    result =
-      if Map.has_key?(conn.params, "names") do
-        conn.params
-        |> Map.get("names")
-        |> String.split(",")
-        |> Enum.filter(&(String.length(&1) > 0))
-        |> Enum.map(&URI.decode(&1))
-        |> Enum.map(&LiveShareSpaces.SpaceStore.space(&1))
-      else
-        []
-      end
-
     conn
-    |> send_resp(:ok, Poison.encode!(result))
+    |> send_resp(
+      :ok,
+      Poison.encode!(LiveShareSpaces.SpaceStore.spaces_with_member(conn.auth_context.email))
+    )
   end
 
   get "/v0/top_spaces" do

--- a/service/lib/spaces/spaceStore.ex
+++ b/service/lib/spaces/spaceStore.ex
@@ -112,6 +112,20 @@ defmodule LiveShareSpaces.SpaceStore do
     |> update_with_thanks_count()
   end
 
+  def member_of_space?(member_email, space_name) do
+    members_of(space_name)
+    |> Enum.map(&Map.get(&1, "email"))
+    |> Enum.filter(&(&1 == member_email))
+    |> Enum.empty?()
+    |> Kernel.not()
+  end
+
+  def spaces_with_member(member_email) do
+    all_space_names()
+    |> Enum.filter(&member_of_space?(member_email, &1))
+    |> Enum.map(&space(&1))
+  end
+
   def update_with_thanks_count(space) do
     thanks = space |> Map.get("thanks", [])
 


### PR DESCRIPTION
With this change, we **no longer rely on local storage** for names of joined spaces. The service is the source of truth. This ensures that all clients have the same list of joined spaces for a member.

Once this is merged, I will delete the local storage code in the extension.