### PR TITLE
fix joining duplicate space

### DIFF
--- a/service/lib/spaces/http.ex
+++ b/service/lib/spaces/http.ex
@@ -81,6 +81,7 @@ defmodule LiveShareSpaces.HTTP do
 
   get "/v0/load" do
     IO.inspect(conn.auth_context)
+
     conn
     |> send_resp(
       :ok,
@@ -96,13 +97,17 @@ defmodule LiveShareSpaces.HTTP do
   end
 
   defp join_space(space, member, conn) do
-    updated_space = LiveShareSpaces.SpaceStore.add_member(space, member)
+    unless LiveShareSpaces.SpaceStore.member?(space, member["email"]) do
+      updated_space = LiveShareSpaces.SpaceStore.add_member(space, member)
 
-    LiveShareSpaces.Events.send(:member_joined, updated_space["name"], %{
-      email: member["email"]
-    })
+      LiveShareSpaces.Events.send(:member_joined, updated_space["name"], %{
+        email: member["email"]
+      })
 
-    send_resp(conn, :ok, Poison.encode!(updated_space))
+      send_resp(conn, :ok, Poison.encode!(updated_space))
+    else
+      send_resp(conn, :ok, Poison.encode!(space))
+    end
   end
 
   post "/v0/join" do

--- a/service/lib/spaces/spaceStore.ex
+++ b/service/lib/spaces/spaceStore.ex
@@ -232,12 +232,7 @@ defmodule LiveShareSpaces.SpaceStore do
   defp add_member_helper(space, member) do
     current_members = space |> Map.get("members", [])
     member_email = member["email"]
-
-    existing_member =
-      Enum.member?(
-        current_members |> Enum.map(&Map.get(&1, "email")),
-        member_email
-      )
+    existing_member = member?(space, member_email)
 
     if existing_member do
       space
@@ -261,6 +256,13 @@ defmodule LiveShareSpaces.SpaceStore do
     update(
       space,
       &add_member_helper(&1, member)
+    )
+  end
+
+  def member?(space, member_email) do
+    Enum.member?(
+      space |> Map.get("members", []) |> Enum.map(&Map.get(&1, "email")),
+      member_email
     )
   end
 

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -53,24 +53,26 @@ export const reducer: redux.Reducer = (
     case ACTION_JOIN_SPACE:
       return {
         ...state,
-        spaces: sorted([
-          ...state.spaces,
-          {
-            name: action.name,
-            members: [],
-            broadcasts: [],
-            helpRequests: [],
-            codeReviews: [],
-            isLoading: true,
-            isLeaving: false,
-            isExpanded: false,
-            founders: [],
-            blocked_members: [],
-            isPrivate: !!action.key,
-            key: action.key,
-            isMuted: true
-          }
-        ])
+        spaces: state.spaces.find(({ name }) => name === action.name)
+          ? state.spaces
+          : sorted([
+              ...state.spaces,
+              {
+                name: action.name,
+                members: [],
+                broadcasts: [],
+                helpRequests: [],
+                codeReviews: [],
+                isLoading: true,
+                isLeaving: false,
+                isExpanded: false,
+                founders: [],
+                blocked_members: [],
+                isPrivate: !!action.key,
+                key: action.key,
+                isMuted: true
+              }
+            ])
       };
 
     case ACTION_JOIN_SPACE_COMPLETED:


### PR DESCRIPTION
* On service: don't create a "has joined space" event if the member is already in the space
* On extension: don't create a new tree entry if the space already exists