### PR TITLE
Add config setting for custom service uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,9 +335,15 @@
           "type": "string",
           "enum": [
             "prod",
-            "local"
+            "local",
+            "custom"
           ],
           "description": "Specifies the services endpoint URI"
+        },
+        "liveshare.spaces.customServiceUri": {
+          "default": "",
+          "type": "string",
+          "description": "Specifies the URI of a custom service endpoint when Service Uri is set to 'custom'"
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ const MUTED_SPACES = "mutedSpaces";
 const SUGGESTED_CONTACTS_SETTING = "showSuggestedContacts";
 const INSIDERS = "insiders";
 const SERVICE_URI_SETTING = "serviceUri";
+const CUSTOM_SERVICE_URI_SETTING = "customServiceUri";
 
 export enum SuggestionBehavior {
   ignore = "ignore",
@@ -52,7 +53,13 @@ export const config = {
 
   get serviceUri() {
     const value = this.getConfig().get<string>(SERVICE_URI_SETTING)!;
-
-    return value === "prod" ? PROD_SERVICE_URL : LOCAL_SERVICE_URL;
+    switch (value) {
+      case "prod":
+        return PROD_SERVICE_URL;
+      case "local":
+        return LOCAL_SERVICE_URL;
+      default:
+        return this.getConfig().get<string>(CUSTOM_SERVICE_URI_SETTING)!;
+    }
   }
 };


### PR DESCRIPTION
This change adds a settings item that allows a privately hosted instance of the spaces service to be used instead of the publicly available one.